### PR TITLE
Using progress from zimfarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,12 @@ ENV MONGODB_URI mongodb://localhost
 ENV MAIN_PREFIX /api
 ENV ZIMIT_API_URL /api/v1
 ENV ZIMFARM_WEBAPI https://api.farm.youzim.it/v1
+ENV INTERNAL_ZIMFARM_WEBAPI http://dispatcher.backend.zimit.kiwixoffline.node.intern/v1
 ENV _ZIMFARM_USERNAME -
 ENV _ZIMFARM_PASSWORD -
+
+# max --limit for recipes
+# ENV ZIMIT_LIMIT 100
 
 # notifications
 ENV MAILGUN_API_URL https://api.mailgun.net/v3/mg.youzim.it

--- a/api/src/routes/requests.py
+++ b/api/src/routes/requests.py
@@ -15,6 +15,7 @@ from settings import (
     TASK_CPU,
     TASK_MEMORY,
     TASK_DISK,
+    ZIMIT_LIMIT,
     CALLBACK_BASE_URL,
     HOOK_TOKEN,
 )
@@ -51,6 +52,11 @@ class RequestsRoute(BaseRoute):
         # build zimit config
         if not document["flags"].get("name"):
             document["flags"]["name"] = f"{url.hostname}_en_all"
+
+        # make sure we cap requests to ZIMIT_LIMIT at most
+        document["flags"]["limit"] = min(
+            [ZIMIT_LIMIT, document["flags"].get("limit", ZIMIT_LIMIT)]
+        )
 
         config = {
             "task_name": "zimit",
@@ -135,9 +141,6 @@ class RequestRoute(BaseRoute):
         success, status, task = query_api("GET", f"/tasks/{request_id}")
         if status == 404:
             success, status, task = query_api("GET", f"/requested-tasks/{request_id}")
-
-        # do something with returned data?
-        task["progress"] = {"overall": 54}
 
         return jsonify(task)
 

--- a/api/src/settings.py
+++ b/api/src/settings.py
@@ -13,10 +13,20 @@ logger = logging.getLogger(__name__)
 DEFAULT_CPU = 3
 DEFAULT_MEMORY = "1GiB"
 DEFAULT_DISK = "1GiB"
-ZIMFARM_API_URL = os.getenv("ZIMFARM_WEBAPI", "https://api.farm.youzim.it/v1")
+DEFAULT_MAX_LIMIT = 1000
+ZIMFARM_API_URL = os.getenv("INTERNAL_ZIMFARM_WEBAPI", "https://api.farm.youzim.it/v1")
 ZIMFARM_USERNAME = os.getenv("_ZIMFARM_USERNAME", "-")
 ZIMFARM_PASSWORD = os.getenv("_ZIMFARM_PASSWORD", "-")
-ZIMIT_IMAGE = os.getenv("ZIMIT_IMAGE", "openzim/zimit:dev")
+ZIMIT_IMAGE = os.getenv("ZIMIT_IMAGE", "openzim/zimit:1.0")
+try:
+    ZIMIT_LIMIT = int(os.getenv("ZIMIT_LIMIT", DEFAULT_MAX_LIMIT))
+except Exception as exc:
+    logger.error(
+        f"Unable to parse ZIMIT_LIMIT: {os.getenv('ZIMIT_LIMIT')}."
+        f"Using {DEFAULT_MAX_LIMIT}. Error: {exc}"
+    )
+    ZIMIT_LIMIT = DEFAULT_MAX_LIMIT
+
 try:
     TASK_CPU = int(os.getenv("TASK_CPU", DEFAULT_CPU))
 except Exception as exc:

--- a/ui/src/components/Request.vue
+++ b/ui/src/components/Request.vue
@@ -5,11 +5,11 @@
     <div v-if="!error && task">
         <b-progress>
             <b-progress-bar
-            :value="task.progress.overall"
+            :value="progression"
             :variant="progress_variant"
             striped
-            :animated="ongoing && task.progress.overall > 0 && task.progress.overall < 100">
-            {{task.progress.overall.toFixed(0)}}&nbsp;%
+            :animated="ongoing">
+            {{progression.toFixed(0)}}&nbsp;%
             </b-progress-bar>
         </b-progress>
 
@@ -136,6 +136,10 @@
           // succeeded() { return this.task.status == "succeeded" ; },
           succeeded() { return this.task.status == "succeeded" || this.task.status == "scraper_completed" ; }, // awaiting success upload to S3
           failed() { return ["canceled", "cancel_requested", "failed", "scraper_killed"].indexOf(this.task.status) != -1; },
+          progression() {
+            if (this.ended)
+              return 100;
+            return (this.task.container && this.task.container.progress && this.task.container.progress.overall) ? this.task.container.progress.overall : 0; },
           progress_variant() {
             if (this.succeeded === true)
                 return "success";

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -14,7 +14,7 @@ export default {
   ALERT_DEFAULT_DURATION: 5,
   ALERT_LONG_DURATION: 10,
   ALERT_PERMANENT_DURATION: true,
-  zimit_fields: ["lang", "title", "description", "favicon", "zim_file",
+  zimit_fields: ["lang", "title", "description", "favicon", "zim_file", "limit",
                  "tags", "creator", "source", "include_domains", "exclude",
                  "wait_until", "scope", "scroll", "page", "use_sitemap", "mobile_device"],
   contact_email: "contact+zimit@kiwix.org",


### PR DESCRIPTION
- Using openzim/zimit:1.0 by default
- Added new ZIMIT_LIMIT setting (1000 by default)
- Use *at-most* this value in flags
- Stopped overwriting `progress` in API
- Allow setting limit in UI
- Display 100% on completed status
- Using different env for zimfarm access from API and from UI (sloppy limitation