### PR TITLE
Propose the 'Not set' value only if flag is not required

### DIFF
--- a/ui/src/components/NewRequest.vue
+++ b/ui/src/components/NewRequest.vue
@@ -162,7 +162,9 @@
               if (field.type == "string-enum") {
                 component = "b-form-select";
                 options = field.choices.map(function (option) { return {text: option, value: option}; });
-                options.push({text: "Not set", value: undefined});
+                if (field.required != true) {
+                  options.push({text: "Not set", value: undefined});
+                }
               }
 
               if (field.type == "text") {


### PR DESCRIPTION
## Changes
- In the UI, when the flag type is "StringEnum", the "Not set" option is not shown in the combobox when the flag is required