### PR TITLE
Zimfarm endpoint now contains flags as subkey in dictionary

### DIFF
--- a/ui/src/components/NewRequest.vue
+++ b/ui/src/components/NewRequest.vue
@@ -112,11 +112,11 @@
       },
       computed: {
         editorReady() {
-            return this.form && this.offliner_def !== null; },
+            return this.form && this.offliner_flags !== null; },
         form_fields() {
             let fields = [];
-            for (var i=0;i<this.offliner_def.length;i++) {
-              let field = this.offliner_def[i];
+            for (var i=0;i<this.offliner_flags.length;i++) {
+              let field = this.offliner_flags[i];
               let component = "b-form-input";
               let options = null;
               let component_type = null;
@@ -195,7 +195,7 @@
       },
       methods: {
         loadRecipeDefinition(force_reload, on_success, on_error) {
-            if (!force_reload && this.$store.getters.offliner_def.length){
+            if (!force_reload && this.$store.getters.offliner_flags.length){
                 if (on_success) { on_success(); }
                 return;
             }
@@ -205,8 +205,7 @@
             parent.toggleLoader("fetching definition…");
             parent.queryAPI('get', Constants.zimfarm_webapi + '/offliners/zimit')
               .then(function (response) {
-                  let definition = response.data.filter(field => Constants.zimit_fields.indexOf(field.key) > -1);
-                  parent.$store.dispatch('setOfflinerDef', definition);
+                  parent.$store.dispatch('setOfflinerDef', response.data);
 
                   if (on_success) { on_success(); }
               })

--- a/ui/src/components/mixins.js
+++ b/ui/src/components/mixins.js
@@ -8,7 +8,7 @@ export default {
   },
   computed: {
     publicPath() { return process.env.BASE_URL; },  // for static files linking
-    offliner_def() { return this.$store.getters.offliner_def; }, // offliner def for requests
+    offliner_flags() { return this.$store.getters.offliner_flags; }, // offliner flags for requests
   },
   methods: {
     toggleLoader(text) { // shortcut to store's loader status changer

--- a/ui/src/store.js
+++ b/ui/src/store.js
@@ -1,6 +1,7 @@
 
 import Vue from 'vue'
 import Vuex from 'vuex'
+import Constants from './constants.js'
 
 Vue.use(Vuex);
 
@@ -9,7 +10,7 @@ const store = new Vuex.Store({
     loading: false,
     loading_text: "",
 
-    offliner_def: [],
+    offliner_def: null,
   },
   mutations: {
     setLoading (state, payload) { // toggle GUI loader
@@ -31,6 +32,12 @@ const store = new Vuex.Store({
   getters: {
     loadingStatus(state) { return {should_display: state.loading, text: state.loading_text};},
     offliner_def(state) { return state.offliner_def; },
+    offliner_flags(state) { 
+      if (!state.offliner_def) {
+        return []
+      }
+      return state.offliner_def.flags.filter(field => Constants.zimit_fields.indexOf(field.key) > -1);
+    },
   }
 })
 


### PR DESCRIPTION
Currently the "advanced options" do not display anymore

Changes:
- Adapt frontend to changes in https://github.com/openzim/zimfarm/commit/ca857523c29db529eaf6552d82262b05a6b9815a

