### PR TITLE
Set custom default value for content-header-bytes-length

### DIFF
--- a/api/src/zimitfrontend/routes/requests.py
+++ b/api/src/zimitfrontend/routes/requests.py
@@ -67,6 +67,7 @@ def create_task(request: TaskCreateRequest) -> TaskCreateResponse:
     flags["name"] = flags.get("name", schedule_name)
     flags["zim-file"] = flags.get("zim-file", url.hostname) + f"_{ident}.zim"
     flags["userAgentSuffix"] = "zimit.kiwix.org+"
+    flags["content-header-bytes-length"] = 2048
 
     # remove flags we don't want to overwrite
     for flag in ("adminEmail", "output", "statsFilename"):


### PR DESCRIPTION
We have regular occurrences of zimit failures due to the charset encoding being too far at the beginning of the HTML document. By default, we expect it to be in the first 1024 bytes. This is a sensible default because recommendations are that this should be at the beginning of the HTML head. Not all sites follow this convention, and many are far from that.

I propose to override default content-header-bytes-length only on zimit-frontend to accommodate more sites for non-knowledgeable persons.

We do not want to expose this setting on zimit.kiwix.org because it is too complex.

We should not change warc2zim default (1024) which is still the best comprise value, when you have someone knowledgeable using the tool, because it avoid spending too much resources on this.

WDYT?

