### PR TITLE
Add option to disable requesting new tasks

### DIFF
--- a/dev/zimit_ui_dev/config.json
+++ b/dev/zimit_ui_dev/config.json
@@ -1,4 +1,5 @@
 {
+  "stop_new_requests_on": false,
   "zimit_ui_api": "http://localhost:8002/api/v1",
   "zimfarm_api": "http://localhost:8004/v1",
   "wikipedia_offline_article": "https://en.wikipedia.org/wiki/Offline",

--- a/locales/en.json
+++ b/locales/en.json
@@ -40,7 +40,8 @@
     "errorFetchingDefinition": "Error fetching offliner definition",
     "creatingRequest": "Creating request…",
     "errorCreatingRequest": "Error creating request",
-    "offlinerNotFound": "Zimit offliner not found, we probably experience a serious issue on our infrastructure."
+    "offlinerNotFound": "Zimit offliner not found, we probably experience a serious issue on our infrastructure.",
+    "stopNewRequestsMessage": "Zimit temporarily does not accept new tasks for maintenance, will be back in few days."
   },
   "notFound": {
     "heading": "Not Found",

--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -45,7 +45,8 @@
 		"errorFetchingDefinition": "This is the message when fetching the task definition failed.",
 		"creatingRequest": "This is the message while creating a Zimfarm request.",
 		"errorCreatingRequest": "This is the message when creating a Zimfarm request failed.",
-		"offlinerNotFound": "This is the message when we failed to load offliner definition through API call."
+		"offlinerNotFound": "This is the message when we failed to load offliner definition through API call.",
+		"stopNewRequestsMessage": "This is the message when new requests can temporarily not be submitted anymore."
 	},
 	"notFound": {
 		"heading": "This is the heading displayed when URL is not found/handled.",

--- a/ui/public/config.json
+++ b/ui/public/config.json
@@ -1,4 +1,5 @@
 {
+  "stop_new_requests_on": false,
   "zimit_ui_api": "/api/v1",
   "zimfarm_api": "https://api.farm.zimit.kiwix.org/v1",
   "wikipedia_offline_article": "https://en.wikipedia.org/wiki/Offline",

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -4,6 +4,7 @@ import type { PiniaPluginContext } from 'pinia'
 import constants from './constants'
 
 export type Config = {
+  stop_new_requests_on: boolean
   zimit_ui_api: string
   zimfarm_api: string
   wikipedia_offline_article: string

--- a/ui/src/views/NewRequest.vue
+++ b/ui/src/views/NewRequest.vue
@@ -24,7 +24,10 @@ onMounted(() => {
     <div v-if="mainStore.offlinerNotFound" class="red">
       {{ $t('newRequest.offlinerNotFound') }}
     </div>
-    <div>Website is currently under maintenance, we will be back in few days.</div>
+    <div v-if="mainStore.config.stop_new_requests_on">
+      {{ $t('newRequest.stopNewRequestsMessage') }}
+    </div>
+    <NewRequestForm v-else />
     <FaqList class="faq" />
   </v-container>
 </template>


### PR DESCRIPTION
Fix #117 

Rather than putting the whole website under maintenance, I consider that we in fact prefer to only stop the possibility to request new tasks (like currently). Hence this PR which only stop that.

With this modification, users cannot submit new tasks but they can still see the status of their tasks, access link to download files, ...

Note that this is done at UI level, meaning someone a bit clever could theoritically still submit tasks directly at API level. But it is way simpler to implement than a switch at API level, and probably far sufficient for now.

Message displayed is localized.

| Normal | Stopping new tasks submission |
|--|--|
| ![Screenshot 2025-02-17 at 17 02 22](https://github.com/user-attachments/assets/95dc571f-1334-4636-af6a-808d702faf1d) | ![Screenshot 2025-02-17 at 17 02 04](https://github.com/user-attachments/assets/bf31ee7d-ec05-4bb0-9ceb-cd08ff692038) |
