### PR TITLE
Fix handling of requested task hook notification

### DIFF
--- a/api/src/zimitfrontend/routes/utils.py
+++ b/api/src/zimitfrontend/routes/utils.py
@@ -111,7 +111,7 @@ def process_zimfarm_hook_call(
         return HookProcessingResult(hook_response_status=SUCCESS)
 
     # force task fail status, see https://github.com/openzim/zimit-frontend/issues/90
-    if task.files is None or len(task.files) == 0:
+    if task.status != "requested" and (task.files is None or len(task.files) == 0):
         task.status = "failed"
 
     context = {

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       _ZIMFARM_PASSWORD: admin
       TASK_WORKER: worker
       HOOK_TOKEN: a_very_secret_token
+      CALLBACK_BASE_URL: http://zimit_api:80/api/v1/requests/hook
     depends_on:
       - zimfarm_api
   zimit_ui_dev:


### PR DESCRIPTION
Fix #74

Small fixes:
- set proper callback URL in dev docker-compose
- do not force event as `failed` when there is no file produced and event is `requested` (it is normal to not have any files)