### PR TITLE
Display task rank in processing pipe when waiting for a slot

### DIFF
--- a/api/src/zimitfrontend/routes/schemas.py
+++ b/api/src/zimitfrontend/routes/schemas.py
@@ -23,6 +23,7 @@ class TaskInfo(CamelModel):
     status: str
     flags: list[TaskInfoFlag]
     progress: int | None
+    rank: int
 
 
 class TaskCreateRequest(CamelModel):
@@ -71,6 +72,7 @@ class ZimfarmTask(BaseModel):
     files: dict[str, ZimfarmTaskFile] | None = None
     notification: ZimfarmTaskNotification | None = None
     container: ZimfarmTaskContainer | None = None
+    rank: int
 
 
 class HookStatus(BaseModel):

--- a/api/src/zimitfrontend/routes/utils.py
+++ b/api/src/zimitfrontend/routes/utils.py
@@ -77,6 +77,7 @@ def get_task_info(task: Any) -> TaskInfo:
             )
             else 0
         ),
+        rank=zimfarm_task.rank,
     )
 
 

--- a/api/tests/unit/routes/test_utils.py
+++ b/api/tests/unit/routes/test_utils.py
@@ -47,6 +47,7 @@ from zimitfrontend.routes.utils import (
                 },
                 "notification": {"ended": {"webhook": ["bla"]}},
                 "container": {"progress": {"partialZim": True}},
+                "rank": 123,
             },
             TaskInfo(
                 id="6341c25f-aac9-41aa-b9bb-3ddee058a0bf",
@@ -60,6 +61,7 @@ from zimitfrontend.routes.utils import (
                     TaskInfoFlag(name="flag2", value="value2"),
                 ],
                 progress=0,
+                rank=123,
             ),
             id="full",
         ),
@@ -68,6 +70,7 @@ from zimitfrontend.routes.utils import (
                 "_id": "6341c25f-aac9-41aa-b9bb-3ddee058a0bf",
                 "config": {"warehouse_path": "/other", "flags": {}},
                 "status": "blu",
+                "rank": 456,
             },
             TaskInfo(
                 id="6341c25f-aac9-41aa-b9bb-3ddee058a0bf",
@@ -77,6 +80,7 @@ from zimitfrontend.routes.utils import (
                 status="blu",
                 flags=[],
                 progress=0,
+                rank=456,
             ),
             id="simple",
         ),
@@ -86,6 +90,7 @@ from zimitfrontend.routes.utils import (
                 "config": {"warehouse_path": "/other", "flags": {}},
                 "container": {"progress": {"partialZim": False}},
                 "status": "bla",
+                "rank": 456,
             },
             TaskInfo(
                 id="6341c25f-aac9-41aa-b9bb-3ddee058a0bf",
@@ -95,6 +100,7 @@ from zimitfrontend.routes.utils import (
                 status="bla",
                 flags=[],
                 progress=0,
+                rank=456,
             ),
             id="limit_not_hit",
         ),
@@ -104,6 +110,7 @@ from zimitfrontend.routes.utils import (
                 "config": {"warehouse_path": "/other", "flags": {}},
                 "container": {"progress": {"overall": 100}},
                 "status": "bla",
+                "rank": 456,
             },
             TaskInfo(
                 id="6341c25f-aac9-41aa-b9bb-3ddee058a0bf",
@@ -113,6 +120,7 @@ from zimitfrontend.routes.utils import (
                 status="bla",
                 flags=[],
                 progress=100,
+                rank=456,
             ),
             id="no_limit_info",
         ),
@@ -145,6 +153,7 @@ DEFAULT_HOOK_TASK = ZimfarmTask.model_validate(
         "notification": {"ended": {"webhook": ["bla"]}},
         "container": {"progress": {"partialZim": True}},
         "flags": {"flag2": "value2", "flag1": "value1"},
+        "rank": 123,
     }
 )
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -55,6 +55,7 @@
     "zimingOf": "Ziming of ",
     "requestingSlot": "Requesting slot",
     "requestRecorded": "Your request has been recorded and is awaiting a slot on our infrastructure to run. While we aim to complete all requests within 24 hours, our infrastructure for this free service is limited and we sometimes experience demand surges, in which case the backlog can take several days to process. Please be patient!",
+    "rankMessage": "Your request is at position {task_rank} in the queue (the lower the better, 0 means this task is the next to start).",
     "requestFailed": "Your request has failed! Sorry about that.",
     "failureReasons": "A number of reasons can lead to a ziming failure. Most of the time this comes from an inadequate URL… Please triple check and create a new request. If that doesn't work, {0}.",
     "failureReasonsLinkContent0": "open a ticket in github",

--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -59,6 +59,7 @@
 		"refreshAuto": "This is the message indicating that page refresh is automated, with a placeholder for refresh interval.",
 		"zimingOf": "This are the words before the website url ('Ziming' is an invented world, based on the fact that we create files with .zim extension, named ZIM files)",
 		"requestingSlot": "This is the message indicating that system is requesting a slot to process the task",
+		"rankMessage": "This is the message indicating position of the task in the processing queue",
 		"requestRecorded": "These are explanations when the system is requesting a slot to process the task",
 		"requestFailed": "This is the message indicating that the task has failed",
 		"failureReasons": "These are explanations about what to do when a task has failed, including a placeholder for a link",

--- a/ui/src/stores/main.ts
+++ b/ui/src/stores/main.ts
@@ -62,6 +62,7 @@ export type TaskData = {
   partialZim: boolean
   downloadLink: string
   progress: number
+  rank: number
 }
 
 export const useMainStore = defineStore('main', {

--- a/ui/src/views/RequestStatus.vue
+++ b/ui/src/views/RequestStatus.vue
@@ -76,7 +76,12 @@ watch(
         <v-alert :title="$t('requestStatus.requestingSlot')" color="warning" variant="tonal">
           <template #text>
             <p>{{ $t('requestStatus.requestRecorded') }}</p>
-            <p>{{ $t('requestStatus.bookmarkUrl') }}</p>
+            <i18n-t keypath="requestStatus.rankMessage" tag="strong">
+              <template #task_rank>
+                {{ mainStore.taskData.rank }}
+              </template>
+            </i18n-t>
+            <p v-if="mainStore.taskData.hasEmail">{{ $t('requestStatus.bookmarkUrl') }}</p>
             <p v-if="mainStore.taskData.hasEmail">{{ $t('requestStatus.emailNotification') }}</p>
             <p v-else>{{ $t('requestStatus.noEmailNotification') }}</p>
           </template>


### PR DESCRIPTION
Fix #32 

![Screenshot 2025-02-21 at 11 21 42](https://github.com/user-attachments/assets/70fd0e25-c5f8-4ad3-a9d3-941dd230ac79)

See line in bold (which is meant to be in bold in production, this is not an emphasis for the screenshot)

Changes:
- retrieve and display information about rank from Zimfarm API
- remove line saying "You can bookmark this URL ..." when user has not given its email, since he MUST bookmark this URL