### PR TITLE
Prevent users from submitting multiple tasks in parallel

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -33,4 +33,4 @@ COPY locales /locales
 
 EXPOSE 80
 
-CMD ["uvicorn", "zimitfrontend.entrypoint:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "zimitfrontend.entrypoint:app", "--host", "0.0.0.0", "--port", "80", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -206,3 +206,8 @@ extraPaths = ["src"]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
 disableBytesTypePromotions = true
+
+executionEnvironments = [
+  { root = "tests", reportPrivateUsage = false},
+  { root = "src" }
+]

--- a/api/src/zimitfrontend/constants.py
+++ b/api/src/zimitfrontend/constants.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-import uuid
+import random
 
 import humanfriendly
 
@@ -107,7 +107,12 @@ class ApiConfiguration:
     callback_base_url = os.getenv(
         "CALLBACK_BASE_URL", "https://zimit.kiwix.org/api/v1/hook"
     )
-    hook_token = os.getenv("HOOK_TOKEN", uuid.uuid4().hex)
+    hook_token = os.getenv("HOOK_TOKEN", random.getrandbits(128).to_bytes(16).hex())
+
+    # tracking
+    digest_key = bytes.fromhex(
+        os.getenv("DIGEST_KEY", random.getrandbits(64).to_bytes(8).hex())
+    )
 
     locales_location = pathlib.Path(os.getenv("LOCALES_LOCATION", "../locales"))
 

--- a/api/src/zimitfrontend/main.py
+++ b/api/src/zimitfrontend/main.py
@@ -8,7 +8,7 @@ from starlette.requests import Request
 
 from zimitfrontend import __about__
 from zimitfrontend.constants import ApiConfiguration, logger
-from zimitfrontend.routes import hook, requests
+from zimitfrontend.routes import hook, requests, tracker
 
 
 class Main:
@@ -73,6 +73,7 @@ class Main:
 
         api.include_router(router=requests.router)
         api.include_router(router=hook.router)
+        api.include_router(router=tracker.router)
 
         self.app.mount(f"/api/{__about__.__api_version__}", api)
 

--- a/api/src/zimitfrontend/routes/schemas.py
+++ b/api/src/zimitfrontend/routes/schemas.py
@@ -31,10 +31,25 @@ class TaskCreateRequest(CamelModel):
     lang: str
     email: str | None = None
     flags: dict[str, Any]
+    unique_id: str | None
 
 
 class TaskCreateResponse(CamelModel):
     id: str
+    new_unique_id: str | None
+
+
+class TaskCancelRequest(CamelModel):
+    unique_id: str | None
+
+
+class TrackerStatusRequest(CamelModel):
+    unique_id: str | None
+
+
+class TrackerStatusResponse(CamelModel):
+    status: str
+    ongoing_tasks: list[str] | None
 
 
 class ZimfarmTaskConfig(BaseModel):

--- a/api/src/zimitfrontend/routes/tracker.py
+++ b/api/src/zimitfrontend/routes/tracker.py
@@ -1,0 +1,39 @@
+from http import HTTPStatus
+
+from fastapi import APIRouter, HTTPException, Request
+
+from zimitfrontend.routes.schemas import TrackerStatusRequest, TrackerStatusResponse
+from zimitfrontend.tracker import tracker
+
+router = APIRouter(
+    prefix="/tracker_status",
+    tags=["all"],
+)
+
+
+@router.post(
+    "",
+    summary="Get information about ongoing tasks and/or possibility to request"
+    " a new task",
+    status_code=200,
+    responses={
+        200: {
+            "description": "Tracking status",
+        },
+    },
+)
+def post_tracker_status(
+    status_request: TrackerStatusRequest, http_request: Request
+) -> TrackerStatusResponse:
+
+    if not http_request.client:
+        raise HTTPException(
+            HTTPStatus.INTERNAL_SERVER_ERROR, detail="http_request.client is missing"
+        )
+
+    tracker_status = tracker.add_task(
+        http_request.client.host, status_request.unique_id, None
+    )
+    return TrackerStatusResponse(
+        status=tracker_status.status.value, ongoing_tasks=tracker_status.ongoing_tasks
+    )

--- a/api/src/zimitfrontend/tracker.py
+++ b/api/src/zimitfrontend/tracker.py
@@ -1,0 +1,193 @@
+import hmac
+from enum import Enum
+from http import HTTPStatus
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from zimitfrontend.constants import ApiConfiguration, logger
+from zimitfrontend.zimfarm import query_api
+
+
+class ClientInfo(BaseModel):
+    # Last known address of the client (will be updated for a given client_id)
+    ip_address: str
+    # Unique identifier of the client
+    unique_id: str
+    # List of client tasks known to not yet have completed
+    ongoing_tasks: list[str]
+
+
+class AddTaskStatus(Enum):
+    TASK_ADDED = "task_added"
+    CAN_ADD_TASK = "can_add_task"
+    TOO_MANY_TASKS_FOR_UNIQUE_ID = "too_many_tasks_for_unique_id"
+    TOO_MANY_TASKS_FOR_IP_ADDRESS = "too_many_tasks_for_ip_address"
+    INVALID_UNIQUE_ID = "invalid_unique_id"
+
+
+class AddTaskResponse(BaseModel):
+    status: AddTaskStatus
+    # ongoing_tasks is populated only when status is TOO_MANY_TASKS_FOR_UNIQUE_ID
+    # since otherwise this is confidential information
+    ongoing_tasks: list[str] | None = None
+    # new_unique_id is populated only when status is TASK_ADDED and unique_id was
+    # not already set
+    new_unique_id: str | None = None
+
+
+class Tracker:
+    def __init__(self):
+        self.known_clients: list[ClientInfo] = []
+        self.ongoing_task_has_finished = self._ongoing_task_has_finished
+        self.has_reached_maximum_tasks = self._has_reached_maximum_tasks
+
+    def _refresh_ongoing_tasks(self, ip_address: str, unique_id: str | None):
+        clients_to_refresh = filter(
+            lambda client: client.ip_address == ip_address
+            or (unique_id and client.unique_id == unique_id),
+            self.known_clients,
+        )
+        completed_clients: list[ClientInfo] = []
+        for client in clients_to_refresh:
+            completed_tasks: list[str] = []
+            for task in client.ongoing_tasks:
+                if self.ongoing_task_has_finished(task):
+                    completed_tasks.append(task)
+            for task in completed_tasks:
+                client.ongoing_tasks.remove(task)
+                if len(client.ongoing_tasks) == 0:
+                    completed_clients.append(client)
+        for client in completed_clients:
+            self.known_clients.remove(client)
+
+    def _has_reached_maximum_tasks(self, client_info: ClientInfo) -> bool:
+        return len(client_info.ongoing_tasks) > 0
+
+    def _ongoing_task_has_finished(self, task_id: str) -> bool:
+        # first try to find the requested task
+        success, status, task = query_api(
+            "GET", f"/requested-tasks/{task_id}?hide_secrets="
+        )
+        if status == HTTPStatus.NOT_FOUND:
+            # if it fails, try to find the task
+            success, status, task = query_api("GET", f"/tasks/{task_id}?hide_secrets=")
+        if not success:
+            logger.warning(
+                f"Unable to find ongoing task {task_id} status via HTTP {status}: "
+                f"{task}"
+            )
+            # failsafe to `True` to clean the situation, might be that we manually
+            # cancelled the requested task which is then simply deleted from DB
+            return True
+        return task["status"] not in [
+            "requested",
+            "cancel_requested",
+            "reserved",
+            "scraper_running",
+            "scraper_started",
+            "started",
+        ]
+
+    def _generate_unique_id(self) -> str:
+        identifier = uuid4().hex
+        digest = hmac.new(
+            ApiConfiguration.digest_key, identifier.encode(), "sha256"
+        ).hexdigest()
+        return f"{identifier}|{digest}"
+
+    def _is_valid_unique_id(self, unique_id: str) -> bool:
+        if "|" not in unique_id:
+            return False
+        splits = unique_id.split("|")
+        if len(splits) != 2:  # noqa: PLR2004
+            return False
+        identifier = splits[0]
+        digest = splits[1]
+        expected_digest = hmac.new(
+            ApiConfiguration.digest_key, identifier.encode(), "sha256"
+        ).hexdigest()
+        return hmac.compare_digest(digest, expected_digest)
+
+    def add_task(
+        self, ip_address: str, unique_id: str | None, task_id: str | None
+    ) -> AddTaskResponse:
+
+        if unique_id and not self._is_valid_unique_id(unique_id):
+            return AddTaskResponse(
+                status=AddTaskStatus.INVALID_UNIQUE_ID,
+            )
+
+        self._refresh_ongoing_tasks(ip_address, unique_id)
+
+        if unique_id:
+            if clients_info_by_unique_id := [
+                client for client in self.known_clients if client.unique_id == unique_id
+            ]:
+                if len(clients_info_by_unique_id) > 1:
+                    raise Exception(
+                        f"Too many data for one single unique id: {unique_id}"
+                    )
+                client_info = clients_info_by_unique_id[0]
+                if self.has_reached_maximum_tasks(client_info) > 0:
+                    return AddTaskResponse(
+                        status=AddTaskStatus.TOO_MANY_TASKS_FOR_UNIQUE_ID,
+                        ongoing_tasks=client_info.ongoing_tasks,
+                    )
+        elif clients_info_by_ip_address := [
+            client for client in self.known_clients if client.ip_address == ip_address
+        ]:
+            if len(clients_info_by_ip_address) > 1:
+                raise Exception(
+                    f"Too many data for one single ip address: {ip_address}"
+                )
+            return AddTaskResponse(
+                status=AddTaskStatus.TOO_MANY_TASKS_FOR_IP_ADDRESS,
+                ongoing_tasks=None,  # Confidential information
+            )
+
+        # when we've reached this point, there is no ongoing task pending for this
+        # client
+
+        if not task_id:
+            # simply inform that we are ok to add task
+            return AddTaskResponse(
+                status=AddTaskStatus.CAN_ADD_TASK,
+                ongoing_tasks=None,
+            )
+
+        if not unique_id:
+            new_unique_id = self._generate_unique_id()  # generate a new unique ID
+            self.known_clients.append(
+                ClientInfo(
+                    ip_address=ip_address,
+                    unique_id=new_unique_id,
+                    ongoing_tasks=[task_id],
+                )
+            )
+            return AddTaskResponse(
+                status=AddTaskStatus.TASK_ADDED,
+                ongoing_tasks=None,
+                new_unique_id=new_unique_id,
+            )
+
+        if clients_info_by_unique_id := [
+            client for client in self.known_clients if client.unique_id == unique_id
+        ]:
+            client_info = clients_info_by_unique_id[0]
+            client_info.ongoing_tasks.append(task_id)
+        else:
+            self.known_clients.append(
+                ClientInfo(
+                    ip_address=ip_address, unique_id=unique_id, ongoing_tasks=[task_id]
+                )
+            )
+
+        return AddTaskResponse(
+            status=AddTaskStatus.TASK_ADDED,
+            ongoing_tasks=None,
+            new_unique_id=None,
+        )
+
+
+tracker = Tracker()

--- a/api/tests/unit/test_tracker.py
+++ b/api/tests/unit/test_tracker.py
@@ -1,0 +1,283 @@
+import pytest
+
+from zimitfrontend.constants import ApiConfiguration
+from zimitfrontend.tracker import AddTaskStatus, ClientInfo, Tracker
+
+CLIENT_1_IP = "172.16.1.1"
+CLIENT_1_ID = (
+    "cf068243341e4e979c35fd4fb82cea5d|"
+    "7abc6ca76820e0d693d8a22ef0bf002f2f25e5c9f937a84998572c67e097e301"
+)
+
+CLIENT_2_IP = "172.16.1.2"
+CLIENT_2_INVALID_ID = "id1"  # this is not a valid ID
+CLIENT_2_VALID_ID = (
+    "c047287b89854bf9b64aa7a1caf359f8|"
+    "8b6dbcad94abf2e872d5a066575241127eee3636bd9d7f25f8b68bb22e34c4d1"
+)  # this is a valid ID
+
+CLIENT_3_IP = "172.16.1.3"
+CLIENT_3_ID = (
+    "751e636176714d45add32deea6f8931c|"
+    "90ced10358a341684e7fb2fb46ce52702e9ac32ed497b20c05c9db913e025ad0"
+)
+
+CLIENT_4_IP = "172.16.1.4"
+CLIENT_4_ID1 = (
+    "989536ffae664d0d9df62701424bedfc|"
+    "cf6134ae38f74ab595880c1e9c1442df2a24edc2e24c045cde884c8ed72a0ea8"
+)
+CLIENT_4_ID2 = (
+    "d7c3ff46bc314ecfbc7268b452f24a32|"
+    "d0a21077e88fd58ccaa40a489b9221f2af4468273525e7736677f5f903ab0cef"
+)
+
+CLIENT_5_IP1 = "172.16.1.5"
+CLIENT_5_IP2 = "172.16.1.6"
+CLIENT_5_ID = (
+    "634ecae47311413c9fd90725e08593e1|"
+    "c31f98c5bd633785b77b2706a6eee35037bcc1356c75cddbe6478e6afe0f8023"
+)
+
+TASK_ID1 = "task_id1"
+TASK_ID2 = "task_id2"
+TASK_ID3 = "task_id3"
+TASK_ID4 = "task_id4"
+TASK_ID5 = "task_id5"
+TASK_ID6 = "task_id6"
+TASK_ID7 = "task_id7"
+TASK_ID8 = "task_id8"
+
+
+@pytest.fixture()
+def tracker() -> Tracker:
+    tracker = Tracker()
+    # known digest key for tests
+    ApiConfiguration.digest_key = bytes.fromhex("723a207d91341918")
+    # test initial status
+    tracker.known_clients = [
+        ClientInfo(
+            ip_address=CLIENT_1_IP,
+            unique_id=CLIENT_1_ID,
+            ongoing_tasks=[TASK_ID4, TASK_ID1],
+        ),
+        ClientInfo(
+            ip_address=CLIENT_3_IP, unique_id=CLIENT_3_ID, ongoing_tasks=[TASK_ID2]
+        ),
+        ClientInfo(
+            ip_address=CLIENT_4_IP, unique_id=CLIENT_4_ID1, ongoing_tasks=[TASK_ID5]
+        ),
+        ClientInfo(  # two unique IDs for one IP, this is a bug
+            ip_address=CLIENT_4_IP, unique_id=CLIENT_4_ID2, ongoing_tasks=[TASK_ID6]
+        ),
+        ClientInfo(
+            ip_address=CLIENT_5_IP1, unique_id=CLIENT_5_ID, ongoing_tasks=[TASK_ID7]
+        ),
+        ClientInfo(  # two client IPs for one unique ID, this is a bug
+            ip_address=CLIENT_5_IP1, unique_id=CLIENT_5_ID, ongoing_tasks=[TASK_ID8]
+        ),
+    ]
+
+    # test logic to get which ongoing task has already finished
+    def custom_ongoing_task_has_finished(task_id: str):
+        return task_id in [
+            TASK_ID1,
+            TASK_ID4,
+        ]
+
+    tracker.ongoing_task_has_finished = custom_ongoing_task_has_finished
+    return tracker
+
+
+@pytest.mark.parametrize(
+    "ip_address, unique_id, task_id, expected_status, expected_ongoing_tasks,"
+    " new_unique_id_is_set",
+    [
+        pytest.param(
+            CLIENT_1_IP,
+            CLIENT_1_ID,
+            None,
+            AddTaskStatus.CAN_ADD_TASK,
+            None,
+            False,
+            id="client_1_uniqueid_notask",
+        ),
+        pytest.param(
+            CLIENT_1_IP,
+            None,
+            None,
+            AddTaskStatus.CAN_ADD_TASK,
+            None,
+            False,
+            id="client_1_nouniqueid_notask",
+        ),
+        pytest.param(
+            CLIENT_2_IP,
+            CLIENT_2_INVALID_ID,
+            None,
+            AddTaskStatus.INVALID_UNIQUE_ID,
+            None,
+            False,
+            id="client_2_invalidid_notask",
+        ),
+        pytest.param(
+            CLIENT_2_IP,
+            CLIENT_2_VALID_ID,
+            None,
+            AddTaskStatus.CAN_ADD_TASK,
+            None,
+            False,
+            id="client_2_validid_notask",
+        ),
+        pytest.param(
+            CLIENT_2_IP,
+            None,
+            None,
+            AddTaskStatus.CAN_ADD_TASK,
+            None,
+            False,
+            id="client_2_nouniqueid_notask",
+        ),
+        pytest.param(
+            CLIENT_3_IP,
+            CLIENT_3_ID,
+            None,
+            AddTaskStatus.TOO_MANY_TASKS_FOR_UNIQUE_ID,
+            [TASK_ID2],
+            False,
+            id="client_3_uniqueid_notask",
+        ),
+        pytest.param(
+            CLIENT_3_IP,
+            None,
+            None,
+            AddTaskStatus.TOO_MANY_TASKS_FOR_IP_ADDRESS,
+            None,
+            False,
+            id="client_3_nouniqueid_notask",
+        ),
+        pytest.param(
+            CLIENT_1_IP,
+            CLIENT_1_ID,
+            TASK_ID3,
+            AddTaskStatus.TASK_ADDED,
+            None,
+            False,
+            id="client_1_uniqueid_task",
+        ),
+        pytest.param(
+            CLIENT_1_IP,
+            None,
+            TASK_ID3,
+            AddTaskStatus.TASK_ADDED,
+            None,
+            True,
+            id="client_1_nouniqueid_task",
+        ),
+        pytest.param(
+            CLIENT_2_IP,
+            CLIENT_2_VALID_ID,
+            TASK_ID3,
+            AddTaskStatus.TASK_ADDED,
+            None,
+            False,
+            id="client_2_validid_task",
+        ),
+        pytest.param(
+            CLIENT_2_IP,
+            None,
+            TASK_ID3,
+            AddTaskStatus.TASK_ADDED,
+            None,
+            True,
+            id="client_2_nouniqueid_task",
+        ),
+    ],
+)
+def test_add_task(
+    tracker: Tracker,
+    ip_address: str,
+    unique_id: str,
+    task_id: str,
+    expected_status: AddTaskStatus,
+    expected_ongoing_tasks: list[str] | None,
+    *,
+    new_unique_id_is_set: bool,
+):
+    result = tracker.add_task(ip_address, unique_id, task_id)
+    assert result.status == expected_status
+    assert result.ongoing_tasks == expected_ongoing_tasks
+    assert (not new_unique_id_is_set) or (
+        result.new_unique_id and len(result.new_unique_id) > 0
+    )
+
+
+def test_duplicate_ip(tracker: Tracker):
+    with pytest.raises(Exception, match="Too many data for one single ip address"):
+        tracker.add_task(CLIENT_5_IP1, None, None)
+
+
+def test_duplicate_unique_id(tracker: Tracker):
+    with pytest.raises(Exception, match="Too many data for one single unique id"):
+        tracker.add_task(CLIENT_5_IP1, CLIENT_5_ID, None)
+
+
+def test_custom_max_tasks(tracker: Tracker):
+    result = tracker.add_task(CLIENT_3_IP, CLIENT_3_ID, None)
+    assert result.status == AddTaskStatus.TOO_MANY_TASKS_FOR_UNIQUE_ID
+    assert result.ongoing_tasks == [TASK_ID2]
+    assert result.new_unique_id is None
+
+    def fake_has_reached_maximum_tasks(client_info: ClientInfo) -> bool:
+        return len(client_info.ongoing_tasks) > 1  # allow up to two tasks
+
+    tracker.has_reached_maximum_tasks = fake_has_reached_maximum_tasks
+
+    result = tracker.add_task(CLIENT_3_IP, CLIENT_3_ID, TASK_ID8)
+    assert result.status == AddTaskStatus.TASK_ADDED
+    assert result.ongoing_tasks is None
+    assert result.new_unique_id is None
+
+
+def test_generate_validate_id(tracker: Tracker):
+    assert tracker._is_valid_unique_id(tracker._generate_unique_id())
+
+
+@pytest.mark.parametrize("prefix, suffix", [("", "a"), ("a", ""), ("a|", "")])
+def test_validate_bad_id(tracker: Tracker, prefix: str, suffix: str):
+    assert not tracker._is_valid_unique_id(
+        prefix + tracker._generate_unique_id() + suffix
+    )
+
+
+@pytest.mark.parametrize(
+    "identifier, is_valid",
+    [
+        (
+            "6e794ce5c6ab4fb18fec35e4845913ec|094055182b0fa885947ed61ae81268a1e09d6071561b3f7417035863f0515559",
+            True,
+        ),
+        (
+            "6e794ce5c6ab4fb18fec35e4845913eb|094055182b0fa885947ed61ae81268a1e09d6071561b3f7417035863f0515559",
+            False,
+        ),
+        (
+            "6e794ce5c6ab4fb18fec35e4845913ec|094055182b0fa885947ed61ae81268a1e09d6071561b3f7417035863f0515558",
+            False,
+        ),
+        (
+            "6e794ce5c6ab4fb18fec35e4845913ec|094055182b0fa885947ed61ae81268a1",
+            False,
+        ),
+        (
+            "6e794ce5c6ab4fb18fec35e4845913ec094055182b0fa885947ed61ae81268a1e09d6071561b3f7417035863f0515559",
+            False,
+        ),
+        (
+            "6e794ce5c6ab4fb18fec35e4845913ec||094055182b0fa885947ed61ae81268a1e09d6071561b3f7417035863f0515559",
+            False,
+        ),
+    ],
+)
+def test_validate_known_ids(tracker: Tracker, identifier: str, *, is_valid: bool):
+    assert tracker._is_valid_unique_id(identifier) == is_valid

--- a/api/tests/unit/test_tracker.py
+++ b/api/tests/unit/test_tracker.py
@@ -1,7 +1,13 @@
 import pytest
 
 from zimitfrontend.constants import ApiConfiguration
-from zimitfrontend.tracker import AddTaskStatus, ClientInfo, Tracker
+from zimitfrontend.tracker import (
+    AddTaskStatus,
+    ClientInfo,
+    Tracker,
+    generate_unique_id,
+    is_valid_unique_id,
+)
 
 CLIENT_1_IP = "172.16.1.1"
 CLIENT_1_ID = (
@@ -239,15 +245,13 @@ def test_custom_max_tasks(tracker: Tracker):
     assert result.new_unique_id is None
 
 
-def test_generate_validate_id(tracker: Tracker):
-    assert tracker._is_valid_unique_id(tracker._generate_unique_id())
+def test_generate_validate_id():
+    assert is_valid_unique_id(generate_unique_id())
 
 
 @pytest.mark.parametrize("prefix, suffix", [("", "a"), ("a", ""), ("a|", "")])
-def test_validate_bad_id(tracker: Tracker, prefix: str, suffix: str):
-    assert not tracker._is_valid_unique_id(
-        prefix + tracker._generate_unique_id() + suffix
-    )
+def test_validate_bad_id(prefix: str, suffix: str):
+    assert not is_valid_unique_id(prefix + generate_unique_id() + suffix)
 
 
 @pytest.mark.parametrize(
@@ -279,5 +283,5 @@ def test_validate_bad_id(tracker: Tracker, prefix: str, suffix: str):
         ),
     ],
 )
-def test_validate_known_ids(tracker: Tracker, identifier: str, *, is_valid: bool):
-    assert tracker._is_valid_unique_id(identifier) == is_valid
+def test_validate_known_ids(identifier: str, *, is_valid: bool):
+    assert is_valid_unique_id(identifier) == is_valid

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -43,6 +43,9 @@ services:
       - "0.0.0.0"
       - --port
       - "80"
+      - --proxy-headers
+      - --forwarded-allow-ips
+      - "*"
       - --reload
       - --reload-dir
       - /usr/local/lib/python3.12/site-packages/zimitfrontend
@@ -55,6 +58,7 @@ services:
       TASK_WORKER: worker
       HOOK_TOKEN: a_very_secret_token
       CALLBACK_BASE_URL: http://zimit-api:80/api/v1/requests/hook
+      DIGEST_KEY: d1a2df7f0a229cc6
     depends_on:
       - zimfarm-api
   zimit-ui-dev:

--- a/locales/en.json
+++ b/locales/en.json
@@ -73,12 +73,11 @@
     "settingsHeading": "Settings",
     "taskNotFound": "Task not found. Either your URL is incorrect, or our service is experiencing an issue.",
     "cancelButton": "Cancel request",
-    "requestCancelRequested": "Your request cancellation has been requested",
-    "requestCancelRequestedExplanation": "Your request is about to be cancelled, our systems are processing the cancellation, it might take few minutes.",
+    "requestCancelRequested": "Your request cancellation has been received",
+    "requestCancelRequestedExplanation": "Your request is being cancelled. This might take a few minutes.",
     "requestCanceled": "Your request has been cancelled",
-    "requestCanceledExplanation": "Your request has been cancelled before completion.",
     "cancellingRequest": "We are cancelling your request",
-    "errorCancellingRequest": "Cancelling your request failed"
+    "errorCancellingRequest": "Cancellation failed"
   },
   "email": {
     "requested": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,8 +36,9 @@
     "emailLabel": "Your e-mail to receive a download link. Address not kept",
     "submit": "Let's ZIM it!",
     "advancedOptions": "advanced options",
-    "fetchingDefinition": "Loading offliner definition…",
+    "fetchingDefinitionAndStatus": "Loading offliner definition and tracker status…",
     "errorFetchingDefinition": "Error fetching offliner definition",
+    "errorFetchingStatus": "Error fetching tracker status",
     "creatingRequest": "Creating request…",
     "errorCreatingRequest": "Error creating request",
     "offlinerNotFound": "Zimit offliner not found, we probably experience a serious issue on our infrastructure.",
@@ -70,7 +71,14 @@
     "emailNotification": "You should have received an email with the current URL. Once the task is completed you will get a second email with a download link (you may thus close this window).",
     "noEmailNotification": "You did not provide us with an email: please bookmark this page before closing the window or you will not be able to retrieve your ZIM file.",
     "settingsHeading": "Settings",
-    "taskNotFound": "Task not found. Either your URL is incorrect, or our service is experiencing an issue."
+    "taskNotFound": "Task not found. Either your URL is incorrect, or our service is experiencing an issue.",
+    "cancelButton": "Cancel request",
+    "requestCancelRequested": "Your request cancellation has been requested",
+    "requestCancelRequestedExplanation": "Your request is about to be cancelled, our systems are processing the cancellation, it might take few minutes.",
+    "requestCanceled": "Your request has been cancelled",
+    "requestCanceledExplanation": "Your request has been cancelled before completion.",
+    "cancellingRequest": "We are cancelling your request",
+    "errorCancellingRequest": "Cancelling your request failed"
   },
   "email": {
     "requested": {
@@ -96,5 +104,15 @@
       "retryLinkContent": "try again",
       "howToCheckSettings": "You can check the settings you used at %{taskLink}."
     }
+  },
+  "blockedRequest": {
+    "blockedMissingReason": "You are blocked but we miss the detailed reason",
+    "contactUsIfPersist": "Please contact us if the situation persist.",
+    "zimitFreeService": "Zimit being a free service, we limit the number of tasks per user.",
+    "quotaReached": "You have reached your quota, please wait for tasks to complete or contact us if you want more quota.",
+    "useLinksBelowToSeeTask": "Please use links below to monitor / cancel ongoing tasks.",
+    "goToTask": "Go to ongoing task {taskLink}",
+    "excessiveUsage": "We've detect excessive usage from your environment, please come back in few hours.",
+    "abnormalUsage": "You are blocked for abnormal usage: {status}"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -41,7 +41,7 @@
 		"emailLabel": "Su dirección de correo electrónico para recibir un enlace de descarga. Dirección no conservada",
 		"submit": "\"¡Vamos a crear un ZIM!\"",
 		"advancedOptions": "Opciones avanzadas",
-		"fetchingDefinition": "Cargando definición de offliner...",
+		"fetchingDefinitionAndStatus": "Cargando definición de offliner...",
 		"errorFetchingDefinition": "Error en la búsqueda de la definición del offliner",
 		"creatingRequest": "Creando solicitud…",
 		"errorCreatingRequest": "Error al crear la solicitud",

--- a/locales/fa.json
+++ b/locales/fa.json
@@ -36,7 +36,7 @@
 		"emailLabel": "ایمیل شما برای دریافت لینک دانلود. آدرس ذخیره نمی‌شود",
 		"submit": "بیایید ZIM کنیم!",
 		"advancedOptions": "گزینه‌های پیشرفته",
-		"fetchingDefinition": "در حال بارگذاری تعریف آفلاینر…",
+		"fetchingDefinitionAndStatus": "در حال بارگذاری تعریف آفلاینر…",
 		"errorFetchingDefinition": "خطا در بارگذاری تعریف آفلاینر",
 		"creatingRequest": "در حال ایجاد درخواست…",
 		"errorCreatingRequest": "خطا در ایجاد درخواست",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -42,7 +42,7 @@
 		"emailLabel": "Votre e-mail pour recevoir un lien de téléchargement. Adresse non conservée",
 		"submit": "On le ZIM !",
 		"advancedOptions": "options avancées",
-		"fetchingDefinition": "Chargement définition de l'offlineur...",
+		"fetchingDefinitionAndStatus": "Chargement définition de l'offlineur...",
 		"errorFetchingDefinition": "Erreur lors de la récupération de la définition de l'offlineur",
 		"creatingRequest": "Création d'une requête…",
 		"errorCreatingRequest": "Erreur lors de la création de la requête",

--- a/locales/he.json
+++ b/locales/he.json
@@ -41,7 +41,7 @@
 		"emailLabel": "הדוא״ל שלך לקבלת קישור להורדה. הכתובת לא נשמרת",
 		"submit": "בואו נשמור את זה ב־ZIM!",
 		"advancedOptions": "אפשרויות מתקדמות",
-		"fetchingDefinition": "טעינת הגדרת של השומר ללא חיבור לרשת…",
+		"fetchingDefinitionAndStatus": "טעינת הגדרת של השומר ללא חיבור לרשת…",
 		"errorFetchingDefinition": "שגיאה באחזור השומר ללא חיבור לרשת",
 		"creatingRequest": "יצירת בקשה…",
 		"errorCreatingRequest": "שגיאה ביצירת בקשה",

--- a/locales/id.json
+++ b/locales/id.json
@@ -41,7 +41,7 @@
 		"emailLabel": "Email Anda untuk menerima tautan unduhan. Alamat tidak disimpan",
 		"submit": "Ayo diZIMkan!",
 		"advancedOptions": "opsi lanjutan",
-		"fetchingDefinition": "Memuat definisi offliner…",
+		"fetchingDefinitionAndStatus": "Memuat definisi offliner…",
 		"errorFetchingDefinition": "Terjadi kesalahan saat mengambil definisi offliner",
 		"creatingRequest": "Membuat permintaan…",
 		"errorCreatingRequest": "Ada kesalahan saat membuat permintaan",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -37,7 +37,7 @@
 		"emailLabel": "다운로드 링크를 받기 위한 이메일입니다. 주소는 보관되지 않습니다",
 		"submit": "ZIM을 해봅시다!",
 		"advancedOptions": "고급 옵션",
-		"fetchingDefinition": "오프라이너 정의를 불러오는 중...",
+		"fetchingDefinitionAndStatus": "오프라이너 정의를 불러오는 중...",
 		"errorFetchingDefinition": "오프라이너 정의를 가져오는 중 오류가 발생했습니다",
 		"creatingRequest": "요청 생성 중…",
 		"errorCreatingRequest": "요청 생성 중 오류가 발생했습니다"

--- a/locales/mk.json
+++ b/locales/mk.json
@@ -38,7 +38,7 @@
 		"emailLabel": "Ваша е-пошта за да добиете врска за преземање. Не ги чуваме адресите",
 		"submit": "Да го ZIM-уваме!",
 		"advancedOptions": "напредни нагодувања",
-		"fetchingDefinition": "Вчитувам определба за вонмрежникот…",
+		"fetchingDefinitionAndStatus": "Вчитувам определба за вонмрежникот…",
 		"errorFetchingDefinition": "Грешка при добивањето на определба за вонмрежникот",
 		"creatingRequest": "Создавам барање…",
 		"errorCreatingRequest": "Грешка при создавањето на барањето"

--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -80,7 +80,6 @@
 		"requestCancelRequested": "This is the title when task cancellation has been requested",
 		"requestCancelRequestedExplanation": "This is the message when task cancellation has been requested",
 		"requestCanceled": "This is the title when task has been cancelled",
-		"requestCanceledExplanation": "This is the message when task has been cancelled",
 		"cancellingRequest": "This is the message when task cancellation is ongoing",
 		"errorCancellingRequest": "This is the popup message when task cancellation has failed"
 	},

--- a/locales/qqq.json
+++ b/locales/qqq.json
@@ -41,7 +41,7 @@
 		"emailLabel": "This is the label for the text box where users will be entering an optional email.",
 		"submit": "This is the text displayed on a button to start the request.",
 		"advancedOptions": "This is the text displayed on a button to display advanced options.",
-		"fetchingDefinition": "This is the message while fetching the task definition.",
+		"fetchingDefinitionAndStatus": "This is the message while fetching the task definition.",
 		"errorFetchingDefinition": "This is the message when fetching the task definition failed.",
 		"creatingRequest": "This is the message while creating a Zimfarm request.",
 		"errorCreatingRequest": "This is the message when creating a Zimfarm request failed.",
@@ -75,7 +75,14 @@
 		"emailNotification": "This is an explanation about what to do while task is processing when email has been provided",
 		"noEmailNotification": "This is an explanation about what to do while task is processing when email has NOT been provided",
 		"settingsHeading": "This is the title of the section detailing task settings",
-		"taskNotFound": "This is the message displayed when the task is not found."
+		"taskNotFound": "This is the message displayed when the task is not found.",
+		"cancelButton": "This is the text of cancel request button",
+		"requestCancelRequested": "This is the title when task cancellation has been requested",
+		"requestCancelRequestedExplanation": "This is the message when task cancellation has been requested",
+		"requestCanceled": "This is the title when task has been cancelled",
+		"requestCanceledExplanation": "This is the message when task has been cancelled",
+		"cancellingRequest": "This is the message when task cancellation is ongoing",
+		"errorCancellingRequest": "This is the popup message when task cancellation has failed"
 	},
 	"email": {
 		"requested": {
@@ -101,5 +108,15 @@
 			"retryLinkContent": "This is the content of a link to try request again",
 			"howToCheckSettings": "This explains how to double-check the settings"
 		}
+	},
+	"blockedRequest": {
+	  "blockedMissingReason": "This is the message indicating the user is blocked for an unknown reason",
+	  "contactUsIfPersist": "This is the message inviting the user to contact us if the situation persist",
+	  "zimitFreeService": "This is the message explaining why there is a quota",
+	  "quotaReached": "This is the message explaining what user should do when quota is reached",
+	  "useLinksBelowToSeeTask": "This is the message explaining the list of ongoing tasks",
+	  "goToTask": "This is the message inviting to open ongoing task",
+	  "excessiveUsage": "This is a more generic message about quota being reached",
+	  "abnormalUsage": "This is a generic error message when we fail to find quota information"
 	}
 }

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -41,7 +41,7 @@
 		"emailLabel": "E-mailul dvs. pentru a primi un link de descărcare. Adresa nu este păstrată",
 		"submit": "Să-l ZIM!",
 		"advancedOptions": "opțiuni avansate",
-		"fetchingDefinition": "Definiţia de încărcare offline...",
+		"fetchingDefinitionAndStatus": "Definiţia de încărcare offline...",
 		"errorFetchingDefinition": "Eroare la preluarea definiției offliner",
 		"creatingRequest": "Se creează cererea...",
 		"errorCreatingRequest": "Eroare la crearea cererii",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -41,7 +41,7 @@
 		"emailLabel": "Din e-post för att få en nedladdningslänk. Adressen sparas inte",
 		"submit": "Låt oss ZIMa det!",
 		"advancedOptions": "avancerade alternativ",
-		"fetchingDefinition": "Laddar ej-uppkopplad-definition...",
+		"fetchingDefinitionAndStatus": "Laddar ej-uppkopplad-definition...",
 		"errorFetchingDefinition": "Det gick inte att hämta ej-uppkopplad-definitionen",
 		"creatingRequest": "Skapa förfrågan...",
 		"errorCreatingRequest": "Det gick inte att skapa förfrågan",

--- a/locales/zh-hans.json
+++ b/locales/zh-hans.json
@@ -42,7 +42,7 @@
 		"emailLabel": "您的电子邮件用于接收下载链接。地址未保存",
 		"submit": "让我们ZIM它吧！",
 		"advancedOptions": "高级选项",
-		"fetchingDefinition": "正在加载离线程序定义...",
+		"fetchingDefinitionAndStatus": "正在加载离线程序定义...",
 		"errorFetchingDefinition": "获取离线程序定义时出错",
 		"creatingRequest": "正在创建请求…",
 		"errorCreatingRequest": "创建请求时出错",

--- a/ui/src/components/BlockRequest.vue
+++ b/ui/src/components/BlockRequest.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useMainStore } from '../stores/main'
+
+const mainStore = useMainStore()
+</script>
+
+<template>
+  <div v-if="!mainStore.trackerStatus">
+    <!--Never supposed to get here-->
+    <p>{{ $t('blockedRequest.blockedMissingReason') }}</p>
+    <p>{{ $t('blockedRequest.contactUsIfPersist') }}</p>
+  </div>
+  <div v-else-if="mainStore.trackerStatus.status == 'too_many_tasks_for_unique_id'">
+    <p>{{ $t('blockedRequest.zimitFreeService') }}</p>
+    <p>{{ $t('blockedRequest.quotaReached') }}</p>
+    <p>{{ $t('blockedRequest.useLinksBelowToSeeTask') }}</p>
+    <p v-for="ongoingTask in mainStore.trackerStatus.ongoingTasks" :key="ongoingTask">
+      <i18n-t keypath="blockedRequest.goToTask" tag="p">
+        <template #taskLink>
+          <RouterLink :to="`/request/${ongoingTask}`">{{ ongoingTask }}</RouterLink>
+        </template>
+      </i18n-t>
+    </p>
+  </div>
+  <div v-else-if="mainStore.trackerStatus.status == 'too_many_tasks_for_ip_address'">
+    <p>{{ $t('blockedRequest.zimitFreeService') }}</p>
+    <p>{{ $t('blockedRequest.excessiveUsage') }}</p>
+    <p>{{ $t('blockedRequest.contactUsIfPersist') }}</p>
+  </div>
+  <div v-else>
+    <!--Never supposed to get here-->
+    <i18n-t keypath="blockedRequest.abnormalUsage" tag="p">
+      <template #status>
+        {{ mainStore.trackerStatus.status }}
+      </template>
+    </i18n-t>
+    <p>{{ $t('blockedRequest.contactUsIfPersist') }}</p>
+  </div>
+</template>
+
+<style type="text/css" scoped>
+p {
+  margin-bottom: 1rem;
+}
+</style>

--- a/ui/src/views/RequestStatus.vue
+++ b/ui/src/views/RequestStatus.vue
@@ -102,11 +102,7 @@ watch(
         </v-alert>
       </div>
       <div v-else-if="mainStore.taskCanceled" class="pt-4 pb-4">
-        <v-alert :title="$t('requestStatus.requestCanceled')" color="error">
-          <template #text>
-            <p class="pt-2">{{ $t('requestStatus.requestCanceledExplanation') }}</p>
-          </template>
-        </v-alert>
+        <v-alert :title="$t('requestStatus.requestCanceled')" color="error"> </v-alert>
       </div>
       <div v-else-if="mainStore.taskFailed" class="pt-4 pb-4">
         <v-alert :title="$t('requestStatus.requestFailed')" color="error">

--- a/ui/src/views/RequestStatus.vue
+++ b/ui/src/views/RequestStatus.vue
@@ -14,7 +14,7 @@ const config = inject<Config>(constants.config)
 let refreshInterval: ReturnType<typeof setInterval> | undefined
 
 onMounted(() => {
-  mainStore.loadTaskId(route.params.taskId)
+  Promise.all([mainStore.getTrackerStatus(), mainStore.loadTaskId(route.params.taskId)])
 
   // Reload task periodically
   if (!config) {
@@ -55,6 +55,13 @@ watch(
         {{ $t('requestStatus.zimingOf')
         }}<a :href="mainStore.taskUrl" target="_blank">{{ mainStore.taskUrl }}</a>
       </h1>
+      <div
+        v-if="mainStore.trackerStatus?.ongoingTasks?.includes(mainStore.taskId)"
+        id="cancel"
+        @click="mainStore.cancelRequest()"
+      >
+        <v-btn color="red">{{ $t('requestStatus.cancelButton') }}</v-btn>
+      </div>
 
       <v-progress-linear
         v-model="mainStore.taskProgression"
@@ -84,6 +91,20 @@ watch(
             <p v-if="mainStore.taskData.hasEmail">{{ $t('requestStatus.bookmarkUrl') }}</p>
             <p v-if="mainStore.taskData.hasEmail">{{ $t('requestStatus.emailNotification') }}</p>
             <p v-else>{{ $t('requestStatus.noEmailNotification') }}</p>
+          </template>
+        </v-alert>
+      </div>
+      <div v-else-if="mainStore.taskCancelRequested" class="pt-4 pb-4">
+        <v-alert :title="$t('requestStatus.requestCancelRequested')" color="error">
+          <template #text>
+            <p class="pt-2">{{ $t('requestStatus.requestCancelRequestedExplanation') }}</p>
+          </template>
+        </v-alert>
+      </div>
+      <div v-else-if="mainStore.taskCanceled" class="pt-4 pb-4">
+        <v-alert :title="$t('requestStatus.requestCanceled')" color="error">
+          <template #text>
+            <p class="pt-2">{{ $t('requestStatus.requestCanceledExplanation') }}</p>
           </template>
         </v-alert>
       </div>
@@ -175,5 +196,9 @@ watch(
 
 th {
   width: 25%;
+}
+
+#cancel {
+  margin: 1rem 0;
 }
 </style>


### PR DESCRIPTION
Fix #56 

# Changes
- (slightly) track users based on their IP address and a uniquely generated tracker ID
- when a user opens the main UI page, there is now four situations:
  - `situation 1`: user has a tracker ID and there is already too many ongoing tasks for this tracker ID => block user and display link(s) to ongoing task
  - `situation 2`: user has no tracker ID but there is already too many ongoing tasks for this tracker ID => block user inviting him to come back later (tasks are probably not his tasks, we do not want to "leak" tasks to other users behind same IP
  - `situation 3`: user has an invalid tracker ID, or other weird situations linked to a user probably trying to tamper our system => block user with quite obscure message avoiding to leak too much details, but still displaying status so that it is a bit easier to debug should this be a bug
  - `situation 4`: we fail to get status (bug, ...) => simple error message
  - `situation 5`: user has quota left for his tracker ID or his IP => display usual UI
- for now, too many tasks for one single user is set at 1 ongoing task, but code is already a bit prepared to have more complex logic (e.g. grant more quota to some users)

| Situation 1 | Situation 2 |
|--|--|
| ![Screenshot 2025-02-27 at 08 44 41](https://github.com/user-attachments/assets/b208cb42-f643-4912-9fc8-0e0fa479dc03) | ![Screenshot 2025-02-27 at 08 45 46](https://github.com/user-attachments/assets/54955034-de01-4665-b49a-9f8f17eb2c8e) |

| Situation 3 | Situation 4 |
|--|--|
| ![Screenshot 2025-02-27 at 08 48 52](https://github.com/user-attachments/assets/e61af1cb-b034-4d19-838e-142adb8009bc) | ![Screenshot 2025-02-27 at 08 41 52](https://github.com/user-attachments/assets/f39005ff-8915-4a4d-b727-b5f6222dd14e) |

Wording can obviously be fine-tuned. Everything is meant to be internationalized.

"Contact us" is really "poor" for now, but I assume this will be solved in https://github.com/openzim/zimit-frontend/issues/93

- add a button to cancel ongoing task 
  - cancellation is only possible when user has a tracker ID (which is normally always the case)

![Screenshot 2025-02-27 at 10 35 05](https://github.com/user-attachments/assets/6d6b9d4f-f17a-4317-97a2-947dedf0b10b)

- handle cases where task is marked for cancellation / cancelled (we can expect this to happen more often and need to provide clear feedback to the user - for now we just displayed that the task was in error, which is wrong)

![Screenshot 2025-02-27 at 10 33 47](https://github.com/user-attachments/assets/a7fdb286-3736-4708-94f9-a0e9e23be02d)

![Screenshot 2025-02-27 at 10 34 13](https://github.com/user-attachments/assets/49b6d04f-4199-4a9d-b58a-dda34a5e0e9a)


# Technical details
- all data about tracking is stored in zimit-frontend API ; for now, we do not have any storage (DB, ...) ; this is hence stored in-memory. This work because we have one single (uvicorn) process. Should we have a need to scale, we should definitely scale at k8s level (more Docker container, not more uvicorn process) and enable sticky sessions by IP so that users are constantly assigned same Docker container. This is obviously not perfect, to be further discussed / solved down the road. 
- all logic to block users based on tracking is done in zimit-frontend API ; this is deemed the most reasonable compromise in terms of coding (IP detection can mostly only be done at API level) but also in terms of "security" (blocking at UI level is fragile in many scenario)
- tracker ID is composed of two parts: `<unique_id>|<digest>`:
  - `<unique_id>` is a randomly generated 64 bits number in hexadecimal representation
  - `<digest>` is the sha-256 HMAC of the `<unique_id>`, in hexadecimal representation again 
    - this allows to prove authenticity of the tracker ID
    - otherwise it is too easy for users to generate new identities by just generating a new unique_id on their own
    - sha-256 is probably overkill, but we do not really mind about size of the HMAC either, so probably a reasonable compromise
 - tracker ID is stored in user local storage, associated with frontend domain
   - storing it in a cookie is more complex due to cross-site concerns between frontend and backend
   - we do not really mind to use JS to add tracker ID in the requests to backend, no real benefit from the automagic nature of cookies

@Popolechien  @kelson42 @rgaudin feedback needed obviously