### PR TITLE
Temporarily automatically reset unique_id

### DIFF
--- a/ui/src/stores/main.ts
+++ b/ui/src/stores/main.ts
@@ -155,17 +155,22 @@ export const useMainStore = defineStore('main', {
       }
     },
     async getTrackerStatus() {
-      const payload = {
-        uniqueId: localStorage.getItem('uniqueId')
-      }
       try {
         const response = (
-          await axios.post<TrackerStatusResponse>(
-            this.config.zimit_ui_api + '/tracker_status',
-            payload
-          )
+          await axios.post<TrackerStatusResponse>(this.config.zimit_ui_api + '/tracker_status', {
+            uniqueId: localStorage.getItem('uniqueId')
+          })
         ).data
         this.trackerStatus = response
+        if (this.trackerStatus.status == 'invalid_unique_id') {
+          localStorage.removeItem('uniqueId')
+          const response = (
+            await axios.post<TrackerStatusResponse>(this.config.zimit_ui_api + '/tracker_status', {
+              uniqueId: null
+            })
+          ).data
+          this.trackerStatus = response
+        }
       } catch (error) {
         this.handleError(this.t('newRequest.errorFetchingStatus'), error)
       }


### PR DESCRIPTION
Deployment in production was wrong because I forgot to set `DIGEST_KEY`.

The digest key was hence randomly generated at each restart. 

Users who have an "old" unique_id (linked to previous `DIGEST_KEY`) can't access the UI anymore.

This code temporarily reset the unique_id should it be wrong, to unblock users.