### PR TITLE
add oauth mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 # ignore worker SSH keys
 id_ed25519*
 id_rsa*
+docker-compose.override.yml

--- a/api/src/zimitfrontend/constants.py
+++ b/api/src/zimitfrontend/constants.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import pathlib
@@ -82,8 +83,20 @@ class ApiConfiguration:
     )
     zimfarm_requests_timeout = _get_time_setting("ZIMFARM_REQUESTS_TIMEOUT", "10s")
     mailgun_requests_timeout = _get_time_setting("MAILGUN_REQUESTS_TIMEOUT", "10s")
+    auth_mode = os.getenv("AUTH_MODE", default="local")
+    zimfarm_oauth_issuer = os.getenv(
+        "ZIMFARM_OAUTH_ISSUER", default="https://ory.login.kiwix.org"
+    )
     zimfarm_username = os.getenv("_ZIMFARM_USERNAME", "-")
     zimfarm_password = os.getenv("_ZIMFARM_PASSWORD", "-")
+    zimfarm_oauth_client_id = os.getenv("ZIMFARM_OAUTH_CLIENT_ID", default="")
+    zimfarm_oauth_client_secret = os.getenv("ZIMFARM_OAUTH_CLIENT_SECRET", default="")
+    zimfarm_oauth_audience_id = os.getenv("ZIMFARM_OAUTH_AUDIENCE_ID", default="")
+    zimfarm_token_renewal_window = datetime.timedelta(
+        seconds=humanfriendly.parse_timespan(
+            os.getenv("ZIMFARM_TOKEN_RENEWAL_WINDOW", default="2m")
+        )
+    )
     zimit_image = os.getenv("ZIMIT_IMAGE", "openzim/zimit:1.2.0")
     zimit_definition_version = os.getenv("ZIMIT_DEFINITION_VERSION", "")
     if not zimit_definition_version:

--- a/api/src/zimitfrontend/zimfarm.py
+++ b/api/src/zimitfrontend/zimfarm.py
@@ -3,9 +3,10 @@ import json
 import logging
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar, cast
 
 import requests
+from requests.auth import HTTPBasicAuth
 
 from zimitfrontend.constants import ApiConfiguration
 
@@ -17,15 +18,98 @@ DELETE = "DELETE"
 logger = logging.getLogger(__name__)
 
 
-class TokenData:
-    ACCESS_TOKEN: str | None = None
-    ACCESS_TOKEN_EXPIRY: datetime.datetime | None = None
-    REFRESH_TOKEN: str | None = None
-    REFRESH_TOKEN_EXPIRY: datetime.datetime | None = None
-
-
 class ZimfarmAPIError(Exception):
     pass
+
+
+def getnow():
+    """naive UTC now"""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+class ZimfarmClientTokenProvider:
+    """Client to generate access tokens to authenticate with Zimfarm API"""
+
+    def __init__(self):
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._expires_at: datetime.datetime = datetime.datetime.fromtimestamp(
+            0, datetime.UTC
+        ).replace(tzinfo=None)
+
+    def _generate_oauth_access_token(self) -> None:
+        """Generate oauth access token and update expires_at."""
+        response = requests.post(
+            f"{ApiConfiguration.zimfarm_oauth_issuer}/oauth2/token",
+            data={
+                "grant_type": "client_credentials",
+                "audience": ApiConfiguration.zimfarm_oauth_audience_id,
+            },
+            auth=HTTPBasicAuth(
+                ApiConfiguration.zimfarm_oauth_client_id,
+                ApiConfiguration.zimfarm_oauth_client_secret,
+            ),
+            timeout=ApiConfiguration.zimfarm_requests_timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        self._access_token = cast(str, payload["access_token"])
+        self._expires_at = getnow() + datetime.timedelta(seconds=payload["expires_in"])
+
+    def _generate_local_access_token(self) -> None:
+        if self._refresh_token:
+            response = requests.post(
+                f"{ApiConfiguration.zimfarm_api_url}/auth/refresh",
+                json={
+                    "refresh_token": self._refresh_token,
+                },
+                timeout=ApiConfiguration.zimfarm_requests_timeout,
+            )
+        else:
+            response = requests.post(
+                f"{ApiConfiguration.zimfarm_api_url}/auth/authorize",
+                json={
+                    "username": ApiConfiguration.zimfarm_username,
+                    "password": ApiConfiguration.zimfarm_password,
+                },
+                timeout=ApiConfiguration.zimfarm_requests_timeout,
+            )
+
+        response.raise_for_status()
+        payload = response.json()
+        self._access_token = cast(str, payload["access_token"])
+        self._refresh_token = cast(str, payload["refresh_token"])
+        self._expires_at = datetime.datetime.fromisoformat(
+            payload["expires_time"]
+        ).replace(tzinfo=None)
+
+    def get_access_token(self, *, force: bool = False) -> str:
+        """Retrieve or generate access token depending on if token has expired."""
+        now = getnow()
+        if (
+            self._access_token is None
+            or force
+            or now >= (self._expires_at - ApiConfiguration.zimfarm_token_renewal_window)
+        ):
+            if ApiConfiguration.auth_mode == "oauth":
+                self._generate_oauth_access_token()
+            elif ApiConfiguration.auth_mode == "local":
+                self._generate_local_access_token()
+            else:
+                raise ValueError(
+                    f"Unknown cms authentication mode: {ApiConfiguration.auth_mode}. "
+                    "Allowed values are: 'local', 'oauth'"
+                )
+        if self._access_token is None:
+            raise ValueError("Failed to generate access token.")
+        return self._access_token
+
+    @property
+    def access_token(self):
+        return self._access_token
+
+
+zimfarm_client_token_provider = ZimfarmClientTokenProvider()
 
 
 def get_url(path: str) -> str:
@@ -41,48 +125,11 @@ def get_token_headers(token: str) -> dict[str, str]:
     }
 
 
-def get_token(username: str, password: str) -> tuple[str, str]:
-    req = requests.post(
-        url=get_url("/auth/authorize"),
-        json={
-            "username": username,
-            "password": password,
-        },
-        timeout=ApiConfiguration.zimfarm_requests_timeout,
-    )
-    req.raise_for_status()
-    return req.json().get("access_token"), req.json().get("refresh_token")
-
-
 def authenticate(*, force: bool = False) -> None:
-    if (
-        not force
-        and TokenData.ACCESS_TOKEN is not None
-        and TokenData.ACCESS_TOKEN_EXPIRY is not None
-        and TokenData.ACCESS_TOKEN_EXPIRY
-        > datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(minutes=2)
-    ):
-        return
-
-    logger.debug(f"authenticate() with force={force}")
-
-    try:
-        access_token, refresh_token = get_token(
-            username=ApiConfiguration.zimfarm_username,
-            password=ApiConfiguration.zimfarm_password,
-        )
-    except Exception:
-        TokenData.ACCESS_TOKEN = TokenData.REFRESH_TOKEN = (
-            TokenData.ACCESS_TOKEN_EXPIRY
-        ) = None
-    else:
-        TokenData.ACCESS_TOKEN, TokenData.REFRESH_TOKEN = access_token, refresh_token
-        TokenData.ACCESS_TOKEN_EXPIRY = datetime.datetime.now(
-            tz=datetime.UTC
-        ) + datetime.timedelta(minutes=59)
-        TokenData.REFRESH_TOKEN_EXPIRY = datetime.datetime.now(
-            tz=datetime.UTC
-        ) + datetime.timedelta(days=29)
+    logger.debug(
+        f"authenticate() with force={force}, auth_mode={ApiConfiguration.auth_mode}"
+    )
+    zimfarm_client_token_provider.get_access_token(force=force)
 
 
 # Generic type variable for the return type of the wrapped function
@@ -104,7 +151,7 @@ def auth_required(func: Callable[P, R]) -> Callable[P, R]:
 def query_api(
     method: str, path: str, payload: Any | None = None, params: Any | None = None
 ) -> tuple[bool, HTTPStatus, Any]:
-    if not TokenData.ACCESS_TOKEN:
+    if not zimfarm_client_token_provider.access_token:
         return (
             False,
             HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -114,7 +161,7 @@ def query_api(
         req = requests.request(
             method.lower(),
             url=get_url(path),
-            headers=get_token_headers(TokenData.ACCESS_TOKEN),
+            headers=get_token_headers(zimfarm_client_token_provider.get_access_token()),
             json=payload,
             params=params,
             timeout=ApiConfiguration.zimfarm_requests_timeout,


### PR DESCRIPTION
## Rationale
This PR adds an additional mode of authentication (via Ory) with the Zimfarm API.

## Changes
- choose authentication mode based on `AUTH_MODE` env var
- make token renewal window configurable


This closes #197 