### PR TITLE
remove category field from recipe payload

### DIFF
--- a/api/src/zimitfrontend/routes/requests.py
+++ b/api/src/zimitfrontend/routes/requests.py
@@ -162,7 +162,6 @@ def create_task(
     payload = {  # pyright: ignore[reportUnknownVariableType]
         "name": recipe_name,
         "language": "eng",
-        "category": "other",
         "periodicity": "manually",
         "tags": [],
         "enabled": True,


### PR DESCRIPTION
## Changes
- remove `category` field from recipe payload sent to zimfarm API

This closes #206 